### PR TITLE
Rahul/android prompt

### DIFF
--- a/src/components/AndroidIosPrompt.tsx
+++ b/src/components/AndroidIosPrompt.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { View, AlertType } from 'react-native'
+
+interface Props {
+    title: string
+    description: string
+    updateFunc: (arg0: string) => unknown
+    type?: AlertType
+}
+
+const AndroidIosPrompt: React.FC<Props> = (props) => {
+    return <View />
+}
+
+export default AndroidIosPrompt

--- a/src/components/AndroidIosPrompt.tsx
+++ b/src/components/AndroidIosPrompt.tsx
@@ -1,15 +1,44 @@
-import React from 'react'
-import { View, AlertType } from 'react-native'
+import React, { useState } from 'react'
+import { AlertType } from 'react-native'
+import { Button, Dialog, Paragraph, Portal, TextInput } from 'react-native-paper'
 
 interface Props {
     title: string
     description: string
     updateFunc: (arg0: string) => unknown
+    visible: boolean
     type?: AlertType
 }
 
 const AndroidIosPrompt: React.FC<Props> = (props) => {
-    return <View />
+    const [text, setText] = useState('')
+
+    // TODO: See if this is even valid. Might want to change this to "updateFunc" if that changes the visible state of the dialog
+    const hideDialog = () => (props.visible = false)
+
+    if (!props.type) {
+        props.type = 'secure-text'
+    }
+
+    return (
+        <Portal>
+            <Dialog visible={props.visible} onDismiss={hideDialog}>
+                <Dialog.Title>{props.title}</Dialog.Title>
+                <Dialog.Content>
+                    <Paragraph>{props.description}</Paragraph>
+                    <TextInput
+                        value={text}
+                        onChangeText={setText}
+                        secureTextEntry={props.type === 'secure-text'}
+                    />
+                </Dialog.Content>
+                <Dialog.Actions>
+                    <Button onPress={hideDialog}>Cancel</Button>
+                    <Button onPress={() => {}}>Done</Button>
+                </Dialog.Actions>
+            </Dialog>
+        </Portal>
+    )
 }
 
 export default AndroidIosPrompt

--- a/src/components/AndroidPrompt.tsx
+++ b/src/components/AndroidPrompt.tsx
@@ -23,13 +23,14 @@ const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
 
     // If we pass no string, nothing will update server side and the dialog will close since the method that's passed
     // in will set this dialog invisible.
-    const hideDialog = (): void => {
+    // We use useCallback for a slight performance increase.
+    const hideDialog = React.useCallback((): void => {
         androidPromptData.updateFunc(null)
         // Once the user hides the dialog, the state for text stays and will show that in a seemingly
         // different dialog.If the user edits their display name to "asdf" and then goes to edit
         // their email, the textinput will already be populated with "asdf".
         setText('')
-    }
+    }, [androidPromptData])
 
     // Avoid errors on optional prop.
     if (androidPromptData.type === undefined) {

--- a/src/components/AndroidPrompt.tsx
+++ b/src/components/AndroidPrompt.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { AlertType } from 'react-native'
-import { Button, Dialog, Paragraph, Portal, TextInput } from 'react-native-paper'
+import { AlertType, StyleSheet } from 'react-native'
+import { Button, Dialog, Portal, TextInput } from 'react-native-paper'
 
 // Making this a separate interface will make the code cleaner when using this component.
 export interface AndroidPromptData {
     title: string
+    textLabel: string
     description: string
     updateFunc: (arg0: string) => unknown
     type?: AlertType
@@ -18,14 +19,19 @@ interface Props {
 // Must treat this as a regular component unlike native iOS Alert.
 
 const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
-    const [text, setText] = React.useState('')
+    const [text, setText] = React.useState<string>('')
 
-    // If we pass no string, nothing will update server side and the dialog will close.
+    // If we pass no string, nothing will update server side and the dialog will close since the method that's passed
+    // in will set this dialog invisible.
     const hideDialog = (): void => {
         androidPromptData.updateFunc(null)
+        // Once the user hides the dialog, the state for text stays and will show that in a seemingly
+        // different dialog.If the user edits their display name to "asdf" and then goes to edit
+        // their email, the textinput will already be populated with "asdf"
+        setText('')
     }
 
-    // Avoid errors on optional prop
+    // Avoid errors on optional prop.
     if (androidPromptData.type === undefined) {
         androidPromptData.type = 'secure-text'
     }
@@ -35,22 +41,39 @@ const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
             <Dialog visible={visible} onDismiss={hideDialog}>
                 <Dialog.Title>{androidPromptData.title}</Dialog.Title>
                 <Dialog.Content>
-                    <Paragraph>{androidPromptData.description}</Paragraph>
                     <TextInput
                         value={text}
+                        label={androidPromptData.textLabel}
+                        placeholder={androidPromptData.description}
+                        style={styles.textInput}
                         onChangeText={setText}
-                        // TODO: Make themeing and stuff
-                        style={{ color: '#FFFFFF', backgroundColor: '#FFFFFF' }}
                         secureTextEntry={androidPromptData.type === 'secure-text'}
                     />
                 </Dialog.Content>
                 <Dialog.Actions>
                     <Button onPress={hideDialog}>Cancel</Button>
-                    <Button onPress={() => androidPromptData.updateFunc(text)}>Done</Button>
+                    <Button
+                        onPress={() => {
+                            androidPromptData.updateFunc(text)
+                            // Same reason as above.
+                            setText('')
+                        }}
+                    >
+                        Done
+                    </Button>
                 </Dialog.Actions>
             </Dialog>
         </Portal>
     )
 }
+
+const styles = StyleSheet.create({
+    // The default text input theme from https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx
+    // If we don't theme this we get the textInput background as the background we set in theme.ts, which is blue and
+    // looks way off
+    textInput: {
+        backgroundColor: '#f6f6f6',
+    },
+})
 
 export default AndroidPrompt

--- a/src/components/AndroidPrompt.tsx
+++ b/src/components/AndroidPrompt.tsx
@@ -27,7 +27,7 @@ const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
         androidPromptData.updateFunc(null)
         // Once the user hides the dialog, the state for text stays and will show that in a seemingly
         // different dialog.If the user edits their display name to "asdf" and then goes to edit
-        // their email, the textinput will already be populated with "asdf"
+        // their email, the textinput will already be populated with "asdf".
         setText('')
     }
 
@@ -70,7 +70,7 @@ const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
 const styles = StyleSheet.create({
     // The default text input theme from https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx
     // If we don't theme this we get the textInput background as the background we set in theme.ts, which is blue and
-    // looks way off
+    // looks way off.
     textInput: {
         backgroundColor: '#f6f6f6',
     },

--- a/src/components/AndroidPrompt.tsx
+++ b/src/components/AndroidPrompt.tsx
@@ -1,42 +1,52 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { AlertType } from 'react-native'
 import { Button, Dialog, Paragraph, Portal, TextInput } from 'react-native-paper'
 
-interface Props {
+// Making this a separate interface will make the code cleaner when using this component.
+export interface AndroidPromptData {
     title: string
     description: string
     updateFunc: (arg0: string) => unknown
-    visible: boolean
     type?: AlertType
 }
 
-// Must treat this as a regular component with Portals unlike the native iOS Alert
+interface Props {
+    androidPromptData: AndroidPromptData
+    visible: boolean
+}
 
-const AndroidPrompt: React.FC<Props> = (props) => {
-    const [text, setText] = useState('')
+// Must treat this as a regular component unlike native iOS Alert.
 
-    // TODO: See if this is even valid. Might want to change this to "updateFunc" if that changes the visible state of the dialog
-    const hideDialog = () => (props.visible = false)
+const AndroidPrompt: React.FC<Props> = ({ androidPromptData, visible }) => {
+    const [text, setText] = React.useState('')
 
-    if (!props.type) {
-        props.type = 'secure-text'
+    // If we pass no string, nothing will update server side and the dialog will close.
+    const hideDialog = (): void => {
+        androidPromptData.updateFunc(null)
+    }
+
+    // Avoid errors on optional prop
+    if (androidPromptData.type === undefined) {
+        androidPromptData.type = 'secure-text'
     }
 
     return (
         <Portal>
-            <Dialog visible={props.visible} onDismiss={hideDialog}>
-                <Dialog.Title>{props.title}</Dialog.Title>
+            <Dialog visible={visible} onDismiss={hideDialog}>
+                <Dialog.Title>{androidPromptData.title}</Dialog.Title>
                 <Dialog.Content>
-                    <Paragraph>{props.description}</Paragraph>
+                    <Paragraph>{androidPromptData.description}</Paragraph>
                     <TextInput
                         value={text}
                         onChangeText={setText}
-                        secureTextEntry={props.type === 'secure-text'}
+                        // TODO: Make themeing and stuff
+                        style={{ color: '#FFFFFF', backgroundColor: '#FFFFFF' }}
+                        secureTextEntry={androidPromptData.type === 'secure-text'}
                     />
                 </Dialog.Content>
                 <Dialog.Actions>
                     <Button onPress={hideDialog}>Cancel</Button>
-                    <Button onPress={() => {}}>Done</Button>
+                    <Button onPress={() => androidPromptData.updateFunc(text)}>Done</Button>
                 </Dialog.Actions>
             </Dialog>
         </Portal>

--- a/src/components/AndroidPrompt.tsx
+++ b/src/components/AndroidPrompt.tsx
@@ -10,7 +10,9 @@ interface Props {
     type?: AlertType
 }
 
-const AndroidIosPrompt: React.FC<Props> = (props) => {
+// Must treat this as a regular component with Portals unlike the native iOS Alert
+
+const AndroidPrompt: React.FC<Props> = (props) => {
     const [text, setText] = useState('')
 
     // TODO: See if this is even valid. Might want to change this to "updateFunc" if that changes the visible state of the dialog
@@ -41,4 +43,4 @@ const AndroidIosPrompt: React.FC<Props> = (props) => {
     )
 }
 
-export default AndroidIosPrompt
+export default AndroidPrompt

--- a/src/routes/modals/ProfileModal.tsx
+++ b/src/routes/modals/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, View, Alert, ScrollView, Platform } from 'react-native'
+import { StyleSheet, View, Alert, AlertType, ScrollView, Platform } from 'react-native'
 import {
     Title,
     Avatar,
@@ -75,21 +75,24 @@ const ProfileModal: React.FC = () => {
     const [androidPromptData, setAndroidPromptData] = React.useState<AndroidPromptData>({
         title: '',
         description: '',
+        textLabel: '',
         updateFunc: () => {},
         type: 'default',
     })
 
     function prompt(
         title: string,
+        androidTextInputLabel: string,
         description: string,
         updateFunc: (arg0: string) => unknown,
-        type?: 'secure-text'
+        type: AlertType
     ) {
         if (Platform.OS === 'ios') {
             Alert.prompt(title, description, updateFunc, type)
         } else if (Platform.OS === 'android') {
             setAndroidPromptData({
                 title,
+                textLabel: androidTextInputLabel,
                 description,
                 // Make a custom updateFunc to ensure the input isn't blank and that the prompt is set to be invisible
                 // after the input.
@@ -97,6 +100,7 @@ const ProfileModal: React.FC = () => {
                     if (arg) {
                         updateFunc(arg)
                     }
+                    // Once the user is done with their changes, hide the prompt.
                     setAndroidPromptVisible(false)
                 },
                 type,
@@ -115,24 +119,36 @@ const ProfileModal: React.FC = () => {
     }
 
     function onEditDisplayName() {
-        prompt('Edit display name', currentUser.displayName, (displayName) => {
-            currentUser
-                .updateProfile({ displayName, photoURL: currentUser.photoURL })
-                .then(forceUpdate)
-        })
+        prompt(
+            'Edit display name',
+            'Display Name',
+            currentUser.displayName,
+            (displayName) => {
+                currentUser
+                    .updateProfile({ displayName, photoURL: currentUser.photoURL })
+                    .then(forceUpdate)
+            },
+            'default'
+        )
     }
 
     async function onEditEmail() {
         await reauth()
 
-        prompt('Edit email', currentUser.email, (email) => {
-            currentUser
-                .updateEmail(email)
-                .then(forceUpdate)
-                .catch((e) => {
-                    Alert.alert('Error', e.toString())
-                })
-        })
+        prompt(
+            'Edit email',
+            'Email',
+            currentUser.email,
+            (email) => {
+                currentUser
+                    .updateEmail(email)
+                    .then(forceUpdate)
+                    .catch((e) => {
+                        Alert.alert('Error', e.toString())
+                    })
+            },
+            'default'
+        )
     }
 
     async function onEditPassword() {
@@ -140,6 +156,7 @@ const ProfileModal: React.FC = () => {
 
         prompt(
             'Edit password',
+            'Password',
             null,
             (password) => {
                 currentUser

--- a/src/routes/modals/ProfileModal.tsx
+++ b/src/routes/modals/ProfileModal.tsx
@@ -163,6 +163,7 @@ const ProfileModal: React.FC = () => {
 
     return (
         <PaperProvider theme={THEME}>
+            {/* TODO: Put different prompts here for Android. Each will have their own props and visible state. Visible state will be toggled by methods like onEditDisplayName if the OS is Android */}
             <View style={styles.root}>
                 <ModalAppBar />
                 <ScrollView>

--- a/src/routes/modals/ProfileModal.tsx
+++ b/src/routes/modals/ProfileModal.tsx
@@ -70,7 +70,7 @@ const ProfileModal: React.FC = () => {
 
     // Since Android doesn't have their own Alert/prompt system, we need to work around it using our own custom Dialog.
     const [isAndroidPromptVisible, setAndroidPromptVisible] = React.useState<boolean>(false)
-    // When the dialog is visible, it'll show using these props. We need to initialize them now or it'll through
+    // When the dialog is visible, it'll show using these props. We need to initialize them now or it'll throw.
     // undefined errors.
     const [androidPromptData, setAndroidPromptData] = React.useState<AndroidPromptData>({
         title: '',
@@ -208,7 +208,7 @@ const ProfileModal: React.FC = () => {
 
     return (
         <PaperProvider theme={THEME}>
-            {/* No reason in rendering the android prompt when iOS doesn't need it */}
+            {/* No reason in rendering the android prompt when iOS doesn't need it. */}
             {Platform.OS === 'android' && (
                 <AndroidPrompt
                     androidPromptData={androidPromptData}

--- a/src/routes/modals/ProfileModal.tsx
+++ b/src/routes/modals/ProfileModal.tsx
@@ -70,7 +70,7 @@ const ProfileModal: React.FC = () => {
 
     // Since Android doesn't have their own Alert/prompt system, we need to work around it using our own custom Dialog.
     const [isAndroidPromptVisible, setAndroidPromptVisible] = React.useState<boolean>(false)
-    // When the dialog is visible, it'll show using these props. We need to initialize them now or it'll throw.
+    // When the dialog is visible, it'll show using these props. We need to initialize them now or it'll throw
     // undefined errors.
     const [androidPromptData, setAndroidPromptData] = React.useState<AndroidPromptData>({
         title: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5211,10 +5211,10 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-notifier@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/change-notifier/-/change-notifier-1.0.0.tgz#112bf2cac80886afd47fa60fc17e5a7b0f46f6b0"
-  integrity sha512-i/a1ncpxnZJvlMPwZPfX9m0Nyb6XxcD+2z6wyMQIXIvfL0AZnGVT296wdCzKZH3Mz+G5WFuliXVvFekwm5zQ5g==
+change-notifier@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/change-notifier/-/change-notifier-1.0.1.tgz#983d91b7498038775f240ae5a64c429b0a47e6d3"
+  integrity sha512-3f9RYJjhZkBxJnVn/SdfDsVDjiQ5Hr0FsyOqb0oxelU32BjATUdh0INqcX47STTozGSHp65TA6kFDA5q+k/Qxg==
 
 chardet@^0.4.0:
   version "0.4.2"


### PR DESCRIPTION
Android doesn't have its own native prompt so we had to make our own.
This prompt relies on the state under `PromptModal.tsx`, which contains the data for what is shown on the dialog and if it's visible or not.

This works on Android fine, does it break on iOS at all? Also, the prompt bug after signing in on iOS does not happen on Android.

![Screenshot_20201018-151912](https://user-images.githubusercontent.com/7365763/96377779-d6e29d00-1155-11eb-9461-8200ea249ec7.jpg)
