### PR TITLE
Force countdown timer to be based off of one timezone

### DIFF
--- a/src/components/DateCountDown.tsx
+++ b/src/components/DateCountDown.tsx
@@ -6,25 +6,31 @@ interface State {
     today: Date
 }
 
+function convertedDate() {
+    let currentDate = new Date()
+    currentDate.setMinutes(currentDate.getMinutes() + currentDate.getTimezoneOffset())
+    currentDate = new Date(currentDate)
+
+    return currentDate
+}
 export default class DateCountDown extends React.Component<{}, State> {
-    readonly hackathonStart = new Date('March 19, 2021 17:00:00') // March 19, 2021 5:00 pm
-    readonly hackathonEnd = new Date('March 21, 2021 17:00:00') // March 21, 2021 5:00 pm
+    readonly hackathonStart = new Date('March 19, 2021 21:00:00') // March 19, 2021 9:00 pm UTC
+    readonly hackathonEnd = new Date('March 21, 2021 21:00:00') // March 21, 2021 9:00 pm UTC
     timerID: NodeJS.Timeout
 
     constructor(props) {
         super(props)
 
         this.state = {
-            today: new Date(),
+            today: convertedDate(),
         }
     }
 
     tick = () => {
         this.setState({
-            today: new Date(),
+            today: convertedDate(),
         })
     }
-
     componentDidMount() {
         // Don't waste processing power on calculation and state updates if time has passed
         if (this.hackathonEnd.getTime() - this.state.today.getTime() >= 0) {
@@ -52,8 +58,7 @@ export default class DateCountDown extends React.Component<{}, State> {
             descriptionText = 'Time left to Submit'
             dateToCalculate = this.hackathonEnd
         }
-
-        const parsedTimeLeft = formatDistanceStrict(new Date(), dateToCalculate)
+        const parsedTimeLeft = formatDistanceStrict(this.state.today, dateToCalculate)
         return <TimeCard title={descriptionText + ':'} time={parsedTimeLeft} />
     }
 }


### PR DESCRIPTION
I think this should work. I switched the start and end to be 4 hours later to match UTC time and added a function to calculate the time based off of time zone offset.