### PR TITLE
Make sure we're only using essential permissions on Android

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,8 @@
     "android": {
       "package": "org.hackpsu.HackPSU",
       "versionCode": 9,
-      "useNextNotificationsApi": true
+      "useNextNotificationsApi": true,
+      "permissions": []
     },
     "notification": {
       "icon": "./assets/images/notification-icon.png",


### PR DESCRIPTION
Went through our permissions and made sure we used the minimum amount, and we weren't missing anything:

https://docs.expo.io/versions/latest/config/app/#permissions